### PR TITLE
#3: Fix git actions for push image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -71,14 +71,19 @@ jobs:
 
       - name: Build and push Docker image with Jib
         if: github.event_name != 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         run: |
           ./gradlew :akira:jib \
-            -Pdocker.username=${{ secrets.DOCKER_USERNAME }} \
-            -Pdocker.password=${{ secrets.DOCKER_PASSWORD }}
+            -Pdocker.username="${DOCKER_USERNAME}" \
+            -Pdocker.password="${DOCKER_PASSWORD}"
 
       - name: Build Docker image with Jib (no push)
         if: github.event_name == 'pull_request'
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         run: |
           ./gradlew :akira:jibDockerBuild \
-            -Pdocker.username=${{ secrets.DOCKER_USERNAME }}
+            -Pdocker.username="${DOCKER_USERNAME}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 build/
 **/build/**
 **/bin/**
+.**ggshield**
 
 # IDE files
 .idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.36.0
+    hooks:
+      - id: ggshield
+        language_version: python3
+        stages: [commit]
+

--- a/akira/build.gradle
+++ b/akira/build.gradle
@@ -27,8 +27,8 @@ dependencies {
     compileOnly libs.lombok
     annotationProcessor libs.lombok
     
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation libs.spring.boot.starter.test
+    testImplementation libs.spring.security.test
 }
 
 tasks.register('npmInstall', Exec) {
@@ -63,25 +63,35 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+def baseImage = 'bellsoft/liberica-openjre-alpine:24'
+def dockerRegistry = providers.gradleProperty('docker.username').getOrElse('akira')
+def imageTag = project.version.toString()
+def fullVersion = project.version.toString()
+
 jib {
     from {
-        image = 'eclipse-temurin:24-jre-alpine'
+        image = "${baseImage}"
     }
     to {
-        def dockerUsername = project.findProperty('docker.username') ?: System.getenv('DOCKER_USERNAME') ?: 'akira'
-        def imageName = project.findProperty('docker.image') ?: 'akira'
-        image = "${dockerUsername}/${imageName}"
-        tags = [project.version.toString(), 'latest']
+        image = "${dockerRegistry}/akira:${imageTag}"
         auth {
-            username = project.findProperty('docker.username') ? System.getenv('DOCKER_USERNAME') : ""
-            password = project.findProperty('docker.password') ? System.getenv('DOCKER_PASSWORD') : ""
+            username = providers.gradleProperty('docker.username')
+                    .orElse(providers.environmentVariable('DOCKER_USERNAME'))
+                    .getOrElse('akira')
+            password = providers.gradleProperty('docker.password')
+                    .orElse(providers.environmentVariable('DOCKER_PASSWORD'))
+                    .getOrElse('')
         }
     }
     container {
+        labels.put 'org.opencontainers.image.version', "${fullVersion}"
+        labels.put 'org.opencontainers.image.title', 'Akira'
+        labels.put 'org.opencontainers.image.description', 'Akira Project'
+        
         jvmFlags = ['-Djava.security.egd=file:/dev/./urandom']
         ports = ['8443']
-        user = 'spring:spring'
         workingDirectory = '/app'
-        creationTime = 'USE_CURRENT_TIMESTAMP'
+        creationTime = "USE_CURRENT_TIMESTAMP"
+        mainClass = 'org.azurecloud.solutions.akira.AkiraApplication'
     }
 }

--- a/akira/build.gradle
+++ b/akira/build.gradle
@@ -73,7 +73,8 @@ jib {
         image = "${baseImage}"
     }
     to {
-        image = "${dockerRegistry}/akira:${imageTag}"
+        image = "${dockerRegistry}/akira"
+        tags = [imageTag, 'latest']
         auth {
             username = providers.gradleProperty('docker.username')
                     .orElse(providers.environmentVariable('DOCKER_USERNAME'))

--- a/docker-akira/docker-compose.yml
+++ b/docker-akira/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       POSTGRES_DB: akira
       POSTGRES_USER: akira
-      POSTGRES_PASSWORD: akira
+      POSTGRES_PASSWORD: # generate any password for postgres
     volumes:
       # - ./postgres-data:/var/lib/postgresql/data
       - ./certs:/etc/postgresql/certs:ro
@@ -40,7 +40,7 @@ services:
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/akira?sslmode=require
       SPRING_DATASOURCE_USERNAME: akira
-      SPRING_DATASOURCE_PASSWORD: akira
+      SPRING_DATASOURCE_PASSWORD: # generate any password for connect to postgres database
       SPRING_SECURITY_USER_NAME: admin
       SPRING_SECURITY_USER_PASSWORD: admin
       # Сертификаты монтируются через volume, пути указываются через переменные окружения

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ postgresql = "42.7.3"
 lombok = "1.18.42"
 springDependencyManagement = "1.1.6"
 httpclient = "4.5.14"
-jib = "3.5.1"
+jib = "3.5.2"
 
 [libraries]
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springBoot" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ jib = "3.5.1"
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web", version.ref = "springBoot" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security", version.ref = "springBoot" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa", version.ref = "springBoot" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "springBoot" }
+spring-security-test = { module = "org.springframework.security:spring-security-test" }
 liquibase-core = { module = "org.liquibase:liquibase-core" }
 telegrambots-spring-boot-starter = { module = "org.telegram:telegrambots-spring-boot-starter", version.ref = "telegrambots" }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI/CD**
> - Updates `.github/workflows/docker-publish.yml` to export `DOCKER_USERNAME`/`DOCKER_PASSWORD` as env vars and pass them to Gradle for `:akira:jib`/`jibDockerBuild`.
> 
> **Build/Jib**
> - In `akira/build.gradle`, switches base image to `bellsoft/liberica-openjre-alpine:24`, composes destination as ``${docker.username}/akira:${version}``, and uses `providers.*` for auth.
> - Adds OCI labels and sets `mainClass`; normalizes `creationTime` and cleans up old fields.
> - Consolidates test dependencies to version catalog aliases.
> 
> **Dev tooling**
> - Adds `.pre-commit-config.yaml` with `ggshield` and ignores `.*ggshield*` in `.gitignore`.
> 
> **Runtime config**
> - In `docker-akira/docker-compose.yml`, replaces hardcoded `POSTGRES_PASSWORD`/`SPRING_DATASOURCE_PASSWORD` with placeholders for user-provided values.
> 
> **Deps catalog**
> - Extends `gradle/libs.versions.toml` with test libraries and the `jib` plugin entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6948ee2cad6cb0ed0d5bf2121107de5eef1363c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->